### PR TITLE
[SER-364] Add codegen script for Apple Silicon

### DIFF
--- a/client/codegen_mac_arm64.sh
+++ b/client/codegen_mac_arm64.sh
@@ -1,10 +1,10 @@
 # Automates build process for Platform codegen on Apple Silicon Macs.
 # This script should be run from the `client` directory.
 
-set -ex
+set -e
 
-CLIENT_DIR=$0
-PLATFORM_DIR=$CLIENT_DIR/..
+CLIENT_DIR=$(realpath $(dirname $0))
+PLATFORM_DIR=$(realpath $CLIENT_DIR/..)
 
 rm -rf $CLIENT_DIR/cs/src/generated
 


### PR DESCRIPTION
When building and testing `codegen` on a Mac with Apple Silicon, both `arm64` and `x86_64` architectures need to be compiled for different stages of the process. This script automates that and has been tested with both dirty & clean build directories on a 2021 MacBook Pro with M1 Max (ARM64).