### PR TITLE
[SER-376] Fix RVec_Keyframe_T not updating vec len and cap

### DIFF
--- a/client/cs/src/RVec_Keyframe.cs
+++ b/client/cs/src/RVec_Keyframe.cs
@@ -36,6 +36,7 @@ namespace Teleportal.Client.Contract.Properties.Channels
             var shared = this.Inner.Value;
             generated.__Internal.TpClientContractPropertiesChannelsRVecKeyframeU8Push((IntPtr)(&shared), e.Inner.Value.p);
             e.Inner = null;  // move from `e`
+            this.Inner = shared;
         }
 
         public unsafe override Keyframe_U8 this[int index]

--- a/client/cs/tests/Keyframe.cs
+++ b/client/cs/tests/Keyframe.cs
@@ -34,13 +34,22 @@ public class TestKeyframe
         var kf2 = new Channels.Keyframe_U8(2, 1.0);
         var kf3 = new Channels.Keyframe_U8(3, 1.5);
 
-        //TODO[SER-376]: safer-ffi appears to not update the c struct's len/capactity.
-        // need to fix that in order for the test to actually work.
+        v.push(kf0);
+        v.push(kf1);
+        v.push(kf2);
+        v.push(kf3);
 
-        // v.push(kf0);
-        // v.push(kf1);
-        // v.push(kf2);
-        // v.push(kf3);
-        // Assert.Equal(0, v[0].Value);
+        Assert.Equal(0, v[0].Value);
+        Assert.Equal(0.0, v[0].Time);
+
+        Assert.Equal(1, v[1].Value);
+        Assert.Equal(0.5, v[1].Time);
+
+        Assert.Equal(2, v[2].Value);
+        Assert.Equal(1.0, v[2].Time);
+
+        Assert.Equal(3, v[3].Value);
+        Assert.Equal(1.5, v[3].Time);
+
     }
 }


### PR DESCRIPTION
Fixed via this tip from the safer-ffi developer: https://github.com/getditto/safer_ffi/issues/118#issuecomment-1152559384