### PR TITLE
[SER-417] Add ball & ground plane prefabs, physics, Unity data source

### DIFF
--- a/demos/unity_states/unity/Assets/Materials.meta
+++ b/demos/unity_states/unity/Assets/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b633eaca59a746d6b133a6e2cbc55e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Materials/Ball.mat
+++ b/demos/unity_states/unity/Assets/Materials/Ball.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Ball
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.21698111, g: 0.21698111, b: 0.21698111, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/demos/unity_states/unity/Assets/Materials/Ball.mat.meta
+++ b/demos/unity_states/unity/Assets/Materials/Ball.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09f3d3d56f5cb4b94b24f61205630f90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Materials/Ball.physicMaterial
+++ b/demos/unity_states/unity/Assets/Materials/Ball.physicMaterial
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!134 &13400000
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Ball
+  dynamicFriction: 0.6
+  staticFriction: 0.6
+  bounciness: 1
+  frictionCombine: 0
+  bounceCombine: 0

--- a/demos/unity_states/unity/Assets/Materials/Ball.physicMaterial.meta
+++ b/demos/unity_states/unity/Assets/Materials/Ball.physicMaterial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98fd8680577684341b8be61efa274d6a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 13400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Materials/GroundPlane.mat
+++ b/demos/unity_states/unity/Assets/Materials/GroundPlane.mat
@@ -1,0 +1,80 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GroundPlane
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0.7
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/demos/unity_states/unity/Assets/Materials/GroundPlane.mat.meta
+++ b/demos/unity_states/unity/Assets/Materials/GroundPlane.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a88555443879d4a4681a1771769307d2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Materials/GroundPlane.physicMaterial
+++ b/demos/unity_states/unity/Assets/Materials/GroundPlane.physicMaterial
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!134 &13400000
+PhysicMaterial:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: GroundPlane
+  dynamicFriction: 0.6
+  staticFriction: 0.6
+  bounciness: 0.96
+  frictionCombine: 0
+  bounceCombine: 0

--- a/demos/unity_states/unity/Assets/Materials/GroundPlane.physicMaterial.meta
+++ b/demos/unity_states/unity/Assets/Materials/GroundPlane.physicMaterial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a9b5f4980957c4b0cbbc06c49c47cdd5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 13400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Prefabs/Ball.prefab
+++ b/demos/unity_states/unity/Assets/Prefabs/Ball.prefab
@@ -1,0 +1,130 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4354708552534542794
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3180802699619777863}
+  - component: {fileID: 2817384896964997778}
+  - component: {fileID: 8418409844216181374}
+  - component: {fileID: 9203546558912634642}
+  - component: {fileID: 6978846109782352424}
+  - component: {fileID: 53396355095041465}
+  m_Layer: 0
+  m_Name: Ball
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3180802699619777863
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2817384896964997778
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8418409844216181374
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 09f3d3d56f5cb4b94b24f61205630f90, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!135 &9203546558912634642
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  m_Material: {fileID: 13400000, guid: 98fd8680577684341b8be61efa274d6a, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &6978846109782352424
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!135 &53396355095041465
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}

--- a/demos/unity_states/unity/Assets/Prefabs/Ball.prefab
+++ b/demos/unity_states/unity/Assets/Prefabs/Ball.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 9203546558912634642}
   - component: {fileID: 6978846109782352424}
   - component: {fileID: 53396355095041465}
+  - component: {fileID: 4450932959291567252}
   m_Layer: 0
   m_Name: Ball
   m_TagString: Untagged
@@ -128,3 +129,15 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4450932959291567252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4354708552534542794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 067ae415693364cf3bde211dedc9e63f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/demos/unity_states/unity/Assets/Prefabs/Ball.prefab.meta
+++ b/demos/unity_states/unity/Assets/Prefabs/Ball.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Prefabs/GroundPlane.prefab
+++ b/demos/unity_states/unity/Assets/Prefabs/GroundPlane.prefab
@@ -1,0 +1,100 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4824605158487100022
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8688180552744252653}
+  - component: {fileID: 2870092797626439431}
+  - component: {fileID: 459885697579285479}
+  - component: {fileID: 8852062490747920860}
+  m_Layer: 0
+  m_Name: GroundPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8688180552744252653
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4824605158487100022}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 5, y: 1, z: 5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2870092797626439431
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4824605158487100022}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &459885697579285479
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4824605158487100022}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a88555443879d4a4681a1771769307d2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &8852062490747920860
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4824605158487100022}
+  m_Material: {fileID: 13400000, guid: a9b5f4980957c4b0cbbc06c49c47cdd5, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}

--- a/demos/unity_states/unity/Assets/Prefabs/GroundPlane.prefab.meta
+++ b/demos/unity_states/unity/Assets/Prefabs/GroundPlane.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50fd867d6111143ecbe74993f10496ab
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Scenes/Test.unity
+++ b/demos/unity_states/unity/Assets/Scenes/Test.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657815, g: 0.49641192, b: 0.57481617, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -125,7 +127,8 @@ NavMeshSettings:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 705507995}
@@ -141,15 +144,18 @@ GameObject:
 Light:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_Enabled: 1
-  serializedVersion: 8
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
   m_SpotAngle: 30
+  m_InnerSpotAngle: 21.802082
   m_CookieSize: 10
   m_Shadows:
     m_Type: 2
@@ -159,6 +165,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -166,23 +190,29 @@ Light:
   m_CullingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+  m_RenderingLayerMask: 1
   m_Lightmapping: 1
   m_LightShadowCasterMode: 0
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &705507995
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -191,7 +221,8 @@ Transform:
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 963194228}
@@ -208,23 +239,26 @@ GameObject:
 AudioListener:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
 --- !u!20 &963194227
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
   m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
   m_SensorSize: {x: 36, y: 24}
   m_LensShift: {x: 0, y: 0}
-  m_GateFitMode: 2
   m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
@@ -256,12 +290,128 @@ Camera:
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &5563462595788758244
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3180802699619777863, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4354708552534542794, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+      propertyPath: m_Name
+      value: Ball
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1dede7fa6b3ad4b2aaca1c4ed03e8713, type: 3}
+--- !u!1001 &8352080153924281560
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4824605158487100022, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_Name
+      value: GroundPlane
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8688180552744252653, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 50fd867d6111143ecbe74993f10496ab, type: 3}

--- a/demos/unity_states/unity/Assets/Scripts.meta
+++ b/demos/unity_states/unity/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3281266286748496cbb87977f482beb9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceType.cs
+++ b/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceType.cs
@@ -1,0 +1,4 @@
+public enum BallStateDataSourceType
+{
+    PLATFORM, UNITY
+}

--- a/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceType.cs.meta
+++ b/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3872bc5a95ece4d9ebfbc6d99edfb4c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs
+++ b/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs
@@ -115,6 +115,7 @@ public class BallStateDataSourceUnity : MonoBehaviour, IBallStateDataSource
     {
         get
         {
+            // Convert to 16-bit raw RGBA
             UnityEngine.Color c = this.meshRenderer.materials[0].color;
             ushort r = (ushort)(c.r * 65535);
             ushort g = (ushort)(c.g * 65535);

--- a/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs
+++ b/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs
@@ -17,6 +17,7 @@ public class BallStateDataSourceUnity : MonoBehaviour, IBallStateDataSource
     void Update()
     {
         // TODO[SER-383]
+        LogCurrentData();
     }
 
     public void LogCurrentData()
@@ -115,10 +116,10 @@ public class BallStateDataSourceUnity : MonoBehaviour, IBallStateDataSource
         get
         {
             UnityEngine.Color c = this.meshRenderer.materials[0].color;
-            ushort r = (ushort)(c.r * 255);
-            ushort g = (ushort)(c.g * 255);
-            ushort b = (ushort)(c.b * 255);
-            ushort a = (ushort)(c.a * 255);
+            ushort r = (ushort)(c.r * 65535);
+            ushort g = (ushort)(c.g * 65535);
+            ushort b = (ushort)(c.b * 65535);
+            ushort a = (ushort)(c.a * 65535);
 
             ulong rgba = (ulong)((r << 48) | (g << 32) | (b << 16) | a);
             return rgba;

--- a/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs
+++ b/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs
@@ -1,0 +1,127 @@
+using UnityEngine;
+
+// Attach to Ball prefab.
+[RequireComponent(typeof(MeshRenderer))]
+public class BallStateDataSourceUnity : MonoBehaviour, IBallStateDataSource
+{
+
+    private MeshRenderer meshRenderer;
+
+    void Awake()
+    {
+        this.meshRenderer = GetComponent<MeshRenderer>();
+
+        // TODO[SER-383]
+    }
+
+    void Update()
+    {
+        // TODO[SER-383]
+    }
+
+    public void LogCurrentData()
+    {
+        string pos = $"({this.pos_x.ToString()}, {this.pos_y.ToString()}, {this.pos_z.ToString()})";
+        string euler = $"({this.euler_x.ToString()}, {this.euler_y.ToString()}, {this.euler_z.ToString()})";
+        string scale = $"({this.scale_x.ToString()}, {this.scale_y.ToString()}, {this.scale_z.ToString()})";
+        string color = $"{this.color.ToString()}";
+
+        string debug_str = $"{pos}\n{euler}\n{scale}\n{color}";
+        Debug.Log(debug_str);
+    }
+
+    public BallStateDataSourceType type
+    {
+        get
+        {
+            return BallStateDataSourceType.UNITY;
+        }
+    }
+
+    public float pos_x
+    {
+        get
+        {
+            return this.transform.position.x;
+        }
+    }
+
+    public float pos_y
+    {
+        get
+        {
+            return this.transform.position.y;
+        }
+    }
+
+    public float pos_z
+    {
+        get
+        {
+            return this.transform.position.z;
+        }
+    }
+
+    public short euler_x
+    {
+        get
+        {
+            return (short)this.transform.eulerAngles.x;
+        }
+    }
+
+    public short euler_y
+    {
+        get
+        {
+            return (short)this.transform.eulerAngles.y;
+        }
+    }
+
+    public short euler_z
+    {
+        get
+        {
+            return (short)this.transform.eulerAngles.z;
+        }
+    }
+
+    public float scale_x
+    {
+        get
+        {
+            return this.transform.localScale.x;
+        }
+    }
+
+    public float scale_y
+    {
+        get
+        {
+            return this.transform.localScale.y;
+        }
+    }
+
+    public float scale_z
+    {
+        get
+        {
+            return this.transform.localScale.z;
+        }
+    }
+
+    public ulong color
+    {
+        get
+        {
+            UnityEngine.Color c = this.meshRenderer.materials[0].color;
+            ushort r = (ushort)(c.r * 255);
+            ushort g = (ushort)(c.g * 255);
+            ushort b = (ushort)(c.b * 255);
+            ushort a = (ushort)(c.a * 255);
+
+            ulong rgba = (ulong)((r << 48) | (g << 32) | (b << 16) | a);
+            return rgba;
+        }
+    }
+}

--- a/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs.meta
+++ b/demos/unity_states/unity/Assets/Scripts/BallStateDataSourceUnity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 067ae415693364cf3bde211dedc9e63f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/Assets/Scripts/IBallStateDataSource.cs.cs
+++ b/demos/unity_states/unity/Assets/Scripts/IBallStateDataSource.cs.cs
@@ -1,0 +1,15 @@
+public interface IBallStateDataSource
+{
+    BallStateDataSourceType type { get; }
+    void LogCurrentData();
+    float pos_x { get; }
+    float pos_y { get; }
+    float pos_z { get; }
+    short euler_x { get; }
+    short euler_y { get; }
+    short euler_z { get; }
+    float scale_x { get; }
+    float scale_y { get; }
+    float scale_z { get; }
+    ulong color { get; }
+}

--- a/demos/unity_states/unity/Assets/Scripts/IBallStateDataSource.cs.cs.meta
+++ b/demos/unity_states/unity/Assets/Scripts/IBallStateDataSource.cs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6beebb1c458942a6a9dff3eb4764793
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/demos/unity_states/unity/ProjectSettings/EditorBuildSettings.asset
+++ b/demos/unity_states/unity/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/Test.unity
+    guid: 9fc0d4010bbf28b4594072e72b8655ab
   m_configObjects: {}


### PR DESCRIPTION
## Overview

This PR:
- Provides an interface for 2 types of data sources for Ball motion: Platform (FFI) based and Unity (game engine) based.
- Implements the Unity data source
- Creates a Ball prefab with a default material, a collider and rigidbody (for physics simulation), and the Unity data source script attached.
- Creates a GroundPlane prefab with a default material, a collider, and a rigidbody.
- Adds both the Ball and GroundPlane prefabs to the Test scene.

The Unity data source script (`BallStateDataSourceUnity.cs`) was tested by temporarily inserting a call to `LogCurrentData()` in its Update loop. All 4 state categories (position, rotation, scale, and color) returned expected values during the simulation.

## Testing

To test, open this project in Unity. Then open `Scenes/Test.unity` from the Project pane. Add the logging call in the script as described above, then press Run and watch the console. Expand any log entry by clicking on it once.

You can change the transform in real-time to see how it updates the data that is logged to the console:

<img width="1728" alt="Screen Shot 2022-07-24 at 1 31 05 AM" src="https://user-images.githubusercontent.com/5103968/180639060-cd8b9aca-a370-4524-9d84-4915819b5694.png">

You can also change the color by double-clicking on the ball's material in the inspector and selecting a new albedo color:

<img width="403" alt="Screen Shot 2022-07-24 at 1 31 45 AM" src="https://user-images.githubusercontent.com/5103968/180639098-7f5540e9-1644-4589-9233-de8f71831ef2.png">

<img width="401" alt="Screen Shot 2022-07-24 at 1 32 00 AM" src="https://user-images.githubusercontent.com/5103968/180639106-8ea1e42d-1c10-45c0-8d56-4bf2b754fd50.png">