### PR TITLE
[SER-472] MSBuild copies dylibs and cppsharp uses OutputNamespace

### DIFF
--- a/client/codegen_pinvoke/Main.cs
+++ b/client/codegen_pinvoke/Main.cs
@@ -112,14 +112,15 @@ namespace Codegen
             options.GenerateClassTemplates = false;
             options.GenerateFinalizers = false;
 
-            var module = options.AddModule(this.lib_info.crate_name);
+            // hard coding "unity_states" as a stopgap until we decide which target
+            // provides all the symbols for the necessary libraries
+            var module = options.AddModule("unity_states");
+            module.Libraries.Add($"libunity_states{Codegen.DYLIB_EXTENSION}");
+            module.OutputNamespace = this.lib_info.crate_name;
+
             module.IncludeDirs.Add(this.lib_info.input_dir.FullName);
             module.Headers.Add("generated.h");
             module.LibraryDirs.Add(this.lib_info.cargo_artifact_dir.FullName);
-            // hard coding "unity_states" as a stopgap until we decide which target
-            // provides all the symbols for the necessary libraries
-            module.Libraries.Add($"libunity_states{Codegen.DYLIB_EXTENSION}");
-            module.LibraryName = this.lib_info.crate_name;
         }
 
         /// Setup your passes here.

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -17,6 +17,33 @@
     <Nullable>enable</Nullable>
 
     <NoWarn>CS8629</NoWarn>
+
+    <!-- This is our own property that determines the native library name. -->
+    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\target\debug\libunity_states</TpNativePrefix>
   </PropertyGroup>
 
+  <!--
+    What the fuck is this shit, I hate MSBuild.
+    Taken from: https://github.com/dotnet/sdk/issues/10575
+
+    Note: When using wildcards in the path, the build won't fail if the file is
+    missing.
+  -->
+  <ItemGroup>
+    <!-- Here, we use the previously defined property -->
+    <NativeLibs Include="$(TpNativePrefix).so*" />
+    <NativeLibs Include="$(TpNativePrefix).dylib*" />
+    <NativeLibs Include="$(TpNativePrefix).dll*" />
+    <NativeLibs Include="$(TpNativePrefix).a*" />
+
+    <None Include="@(NativeLibs)">
+      <!-- <Pack>true</Pack> -->
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- <None Include="_._">
+      <Pack>true</Pack>
+      <PackagePath>lib/netstandard2.0</PackagePath>
+    </None> -->
+  </ItemGroup>
 </Project>

--- a/crates/rsharp/cs/src/RSharp.cs
+++ b/crates/rsharp/cs/src/RSharp.cs
@@ -9,7 +9,7 @@ namespace RSharp
 #if UNITY_IOS && !UNITY_EDITOR
         internal const string LIBRARY_NAME = "__Internal";
 #else
-        internal const string LIBRARY_NAME = "rsharp";
+        internal const string LIBRARY_NAME = "unity_states";
 #endif
     }
 

--- a/crates/rsharp/cs/src/rsharp.csproj
+++ b/crates/rsharp/cs/src/rsharp.csproj
@@ -8,6 +8,33 @@
     <Nullable>enable</Nullable>
 
     <NoWarn>CS8629</NoWarn>
+
+    <!-- This is our own property that determines the native library name. -->
+    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\..\target\debug\libunity_states</TpNativePrefix>
   </PropertyGroup>
 
+  <!--
+    What the fuck is this shit, I hate MSBuild.
+    Taken from: https://github.com/dotnet/sdk/issues/10575
+
+    Note: When using wildcards in the path, the build won't fail if the file is
+    missing.
+  -->
+  <ItemGroup>
+    <!-- Here, we use the previously defined property -->
+    <NativeLibs Include="$(TpNativePrefix).so*" />
+    <NativeLibs Include="$(TpNativePrefix).dylib*" />
+    <NativeLibs Include="$(TpNativePrefix).dll*" />
+    <NativeLibs Include="$(TpNativePrefix).a*" />
+
+    <None Include="@(NativeLibs)">
+      <!-- <Pack>true</Pack> -->
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <!-- <None Include="_._">
+      <Pack>true</Pack>
+      <PackagePath>lib/netstandard2.0</PackagePath>
+    </None> -->
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Eliminates the need for jank symlinking of rust artifacts to dotnet bin folder. Also fixes up `codegen_pinvoke` so that we don't need to manually rename `libunity_states.dylib` -> `libtp_client.dylib`, while letting us continue to keep the namespaces the same.
