### PR TITLE
[SER-485] Overridable DllImport lib name

### DIFF
--- a/client/codegen_pinvoke/Main.cs
+++ b/client/codegen_pinvoke/Main.cs
@@ -35,6 +35,8 @@ namespace Codegen
 
     public sealed class Codegen : CppSharp.ILibrary
     {
+        private const string ENV_VAR_NAME_DLLIMPORT_OVERRIDE = "CONSTELLATION_DLLIMPORT_NAME";
+
         private static DirectoryInfo project_dir = GetProjectDir();
         private readonly LibInfo lib_info;
         private string override_lib_name;
@@ -90,7 +92,7 @@ namespace Codegen
                 }
 
                 // Actually generate the code
-                var override_lib_name = System.Environment.GetEnvironmentVariable("CONSTELLATION_DLLIMPORT_NAME")!;
+                var override_lib_name = System.Environment.GetEnvironmentVariable(ENV_VAR_NAME_DLLIMPORT_OVERRIDE)!;
                 CppSharp.ConsoleDriver.Run(new Codegen(lib, override_lib_name));
             }
 
@@ -106,17 +108,39 @@ namespace Codegen
         /// Setup the driver options here.
         public void Setup(CppSharp.Driver driver)
         {
-            // Copy all DLLs to override location
+            // Copy all DLLs to override location.
+            //
+            // Leaf `csproj`s that contain their own native libraries and depend on this base `csproj` need to
+            // be able to override all `DllImport` arguments at compile time to one single library name.
+            // This is because the base `csproj` exposes client functionality such as `Baseline` and `RBox` to C#,
+            // while a leaf `csproj` may expose its own C# FFI such as custom contracts.
+            //
+            // The Constellation build process in Rust (`cargo build` step) currently outputs a monolithic native library,
+            // so all symbols from both the leaf crate AND the base crate (tp_client + rsharp) are present.
+            // If C# code `DllImport`s from multiple libraries, then references to base and leaf functionality from C#
+            // (e.g. `Baseline` and `MyCustomContract`, respectively) will render unusable because the objects
+            // do not coexist in the same allocation of memory made for each library on `dlopen`.
+            //
+            // CppSharp uses the native library's file name as the argument for `DllImport()`.
+            // (Reference: https://github.com/mono/CppSharp/blob/main/src/Generator/Generators/CSharp/CSharpSources.cs#L3497).
+            // Since there is no parameter we've found in CppSharp to do this override, we copy the base library to
+            // a destination file with the name provided by the environment variable defined in `Codegen.ENV_VAR_NAME_DLLIMPORT_OVERRIDE`.
+            // This "tricks" CppSharp into generating the same symbols in C# while using the overriding name.
+            //
+            // CppSharp codegen is the only process in which this destination file is used.
+            // After this invocation of CppSharp codegen, the copy operation does not affect subsequent compile steps.
+
             var directoryInfo = new DirectoryInfo(this.lib_info.cargo_artifact_dir.FullName);
             var filesList = directoryInfo.GetFiles($"lib{this.lib_info.crate_name}.*");
             foreach (var fileInfo in filesList)
             {
                 var lib_ext = fileInfo.Name.Split('.')[1];
 
+                // Example: Copy `libtp_client.so` -> `libyolo.so`
                 IO.File.Copy(
                     $"{this.lib_info.cargo_artifact_dir.FullName}/lib{this.lib_info.crate_name}.{lib_ext}",
                     $"{this.lib_info.cargo_artifact_dir.FullName}/lib{this.override_lib_name}.{lib_ext}",
-                    true // overwrite if file exists
+                    true // overwrite destination file if it already exists
                 );
             }
 

--- a/client/codegen_pinvoke/Main.cs
+++ b/client/codegen_pinvoke/Main.cs
@@ -88,9 +88,8 @@ namespace Codegen
                     lib.output_dir.Delete(true);
                 }
 
-                const string single_lib_name = "unity_states";
-
                 // Actually generate the code
+                var single_lib_name = args[0];
                 CppSharp.ConsoleDriver.Run(new Codegen(lib, single_lib_name));
             }
 

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="CppSharp.Runtime" Version="1.0.3" />
   </ItemGroup>
 
-
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>9.0</LangVersion>
@@ -19,7 +18,11 @@
     <NoWarn>CS8629</NoWarn>
 
     <!-- This is our own property that determines the native library name. -->
-    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\target\debug\libunity_states</TpNativePrefix>
+    <TpDllImportName Condition="'$(CONSTELLATION_DLLIMPORT_NAME)'==''">unity_states</TpDllImportName>
+
+    <!-- Override if necessary -->
+    <TpDllImportName Condition="'$(CONSTELLATION_DLLIMPORT_NAME)'!=''">'$(CONSTELLATION_DLLIMPORT_NAME)'</TpDllImportName>
+    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\target\debug\lib$(TpDllImportName)</TpNativePrefix>
   </PropertyGroup>
 
   <!-- This automatically handles code generation needed by this library -->
@@ -31,7 +34,7 @@
     <Message Text="Building native library" Importance="high" />
     <Exec Command="cargo build -p unity_states" />
     <Message Text="Running code generators (cpp_sharp)" Importance="high" />
-    <Exec Command="dotnet run -a x64" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\codegen_pinvoke" />
+    <Exec Command="dotnet run -a x64 -- $(TpDllImportName)" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\codegen_pinvoke" />
 
     <ItemGroup>
       <Compile Include="generated\wrapped\*.cs" KeepDuplicates="false"/>

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -18,11 +18,7 @@
     <NoWarn>CS8629</NoWarn>
 
     <!-- This is our own property that determines the native library name. -->
-    <TpDllImportName Condition="'$(CONSTELLATION_DLLIMPORT_NAME)'==''">unity_states</TpDllImportName>
-
-    <!-- Override if necessary -->
-    <TpDllImportName Condition="'$(CONSTELLATION_DLLIMPORT_NAME)'!=''">'$(CONSTELLATION_DLLIMPORT_NAME)'</TpDllImportName>
-    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\target\debug\lib$(TpDllImportName)</TpNativePrefix>
+    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\target\debug\libunity_states</TpNativePrefix>
   </PropertyGroup>
 
   <!-- This automatically handles code generation needed by this library -->
@@ -34,7 +30,7 @@
     <Message Text="Building native library" Importance="high" />
     <Exec Command="cargo build -p unity_states" />
     <Message Text="Running code generators (cpp_sharp)" Importance="high" />
-    <Exec Command="dotnet run -a x64 -- $(TpDllImportName)" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\codegen_pinvoke" />
+    <Exec Command="dotnet run -a x64" WorkingDirectory="$(MSBuildThisFileDirectory)..\..\codegen_pinvoke" />
 
     <ItemGroup>
       <Compile Include="generated\wrapped\*.cs" KeepDuplicates="false"/>

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="CppSharp.Runtime" Version="1.0.3" />
   </ItemGroup>
 
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>9.0</LangVersion>


### PR DESCRIPTION
Passing a value from the leaf (e.g. `movieoke_platform_bridge`) to the base (e.g. `tp_client`) is [off the table](https://social.msdn.microsoft.com/Forums/en-US/2e74c1ae-141d-4483-be5e-bc829cb6483b/how-to-pass-variables-to-referenced-projects?forum=msbuild) and I ran a few other experiments. In the end I found that environment variables are reliable for this use case.

Environment variables can be set at build time if we write a custom MSBuild Task, but any custom env var in the build process is set _after_ the base project is referenced by the leaf. This defeats the whole purpose since the base is built before the environment variable is set. Instead, we set the variable in CLI before invoking `dotnet build`.

To test, use:
```
cd demos/unity_states/cs/src
export CONSTELLATION_DLLIMPORT_NAME="unity_states"
dotnet build
```