### PR TITLE
[SER-491] Fix State accessor for ObjectHandle

### DIFF
--- a/client/cs/src/StateAccessors.cs
+++ b/client/cs/src/StateAccessors.cs
@@ -129,7 +129,7 @@ namespace Teleportal.Client
             var p = new Ptr<States.State_ObjectHandle>(
                 ffi.TpClientBaselineBaselineStateObjectHandle(this.Inner.Value.p, state_handle.Inner.Value.p)
             );
-            return new States.State_ObjectHandle(p, OwnershipSemantics.Owned);
+            return new States.State_ObjectHandle(p, OwnershipSemantics.SharedRef);
         }
 
         public States.State_String StateMut(States.StateHandle_String state_handle)


### PR DESCRIPTION
This PR fixes a ownership flag in `State_ObjectHandle` that was set in C# and caused a crash when used. Once #143 is merged, I will drop the first 2 commits in this branch and set this PR as ready for review.

I am waiting to do so because the open Contracts PR in the Movieoke repo is pointing to this branch temporarily. That Contracts PR needs the changes from all 3 commits from this branch.