### PR TITLE
[SER-492] Move GetDefaults() to ConstellationBuildSettings class

### DIFF
--- a/demos/unity_states/unity/Assets/Plugins/Constellation/Editor/ConstellationBuildPreprocessor.cs
+++ b/demos/unity_states/unity/Assets/Plugins/Constellation/Editor/ConstellationBuildPreprocessor.cs
@@ -13,7 +13,7 @@ public class ConstellationBuildPreprocessor : IPostGenerateGradleAndroidProject
     public int callbackOrder { get { return 0; } }
     public void OnPostGenerateGradleAndroidProject(string unityProjectPath)
     {
-        var buildSettings = GetSettings();
+        var buildSettings = ConstellationBuildSettings.GetDefaults();
         string libDir = $"{unityProjectPath}/src/main/jniLibs";
         foreach (string libName in buildSettings.androidLibNames)
         {
@@ -23,27 +23,4 @@ public class ConstellationBuildPreprocessor : IPostGenerateGradleAndroidProject
             FileUtil.CopyFileOrDirectoryFollowSymlinks(src, dst);
         }
     }
-
-    private ConstellationBuildSettings GetSettings()
-    {
-        var settingsObjects = AssetDatabase.FindAssets("t:ConstellationBuildSettings").ToList()
-            .Select(AssetDatabase.GUIDToAssetPath)
-            .Select(AssetDatabase.LoadAssetAtPath<ConstellationBuildSettings>)
-            .ToList();
-
-        if (settingsObjects.Count == 0)
-        {
-            Debug.LogError($"[Constellation] {ERR_MSG_MISSING_SETTINGS}");
-            return null;
-        }
-        else if (settingsObjects.Count > 1)
-        {
-            Debug.LogError($"[Constellation] {ERR_MSG_TOO_MANY_SETTINGS}");
-            return null;
-        }
-        return settingsObjects[0];
-    }
-
-    private const string ERR_MSG_MISSING_SETTINGS = "Missing build settings! Create one via Assets menu > Create > ScriptableObjects > ConstellationBuildSettings and configure it.";
-    private const string ERR_MSG_TOO_MANY_SETTINGS = "There are more than one ConstellationBuildSettings objects in the project! Remove all except one and check the configuration.";
 }

--- a/demos/unity_states/unity/Assets/Plugins/Constellation/Editor/ConstellationBuildSettings.cs
+++ b/demos/unity_states/unity/Assets/Plugins/Constellation/Editor/ConstellationBuildSettings.cs
@@ -1,8 +1,34 @@
+using System.Linq;
 using UnityEngine;
+using UnityEditor;
 
-[CreateAssetMenu(fileName = "ConstellationBuildSettings", menuName = "ScriptableObjects/ConstellationBuildSettings", order = 1)]
+[CreateAssetMenu(fileName = "ConstellationBuildSettings", menuName = "Teleportal/Constellation Build Settings", order = 1)]
 public class ConstellationBuildSettings : ScriptableObject
 {
+    public string dotnetProjectPath; // e.g. "Platform/cs/src"
     public string androidPluginsDir; // e.g. "Assets/Plugins/Android"
     public string[] androidLibNames; // e.g. "arm64-v8a/unity_states.so"
+
+    public static ConstellationBuildSettings GetDefaults()
+    {
+        var settingsObjects = AssetDatabase.FindAssets("t:ConstellationBuildSettings").ToList()
+            .Select(AssetDatabase.GUIDToAssetPath)
+            .Select(AssetDatabase.LoadAssetAtPath<ConstellationBuildSettings>)
+            .ToList();
+
+        if (settingsObjects.Count == 0)
+        {
+            Debug.LogError($"[Constellation] {ERR_MSG_MISSING_SETTINGS}");
+            return null;
+        }
+        else if (settingsObjects.Count > 1)
+        {
+            Debug.LogError($"[Constellation] {ERR_MSG_TOO_MANY_SETTINGS}");
+            return null;
+        }
+        return settingsObjects[0];
+    }
+
+    private const string ERR_MSG_MISSING_SETTINGS = "Missing build settings. Create one via Assets menu > Create > Teleportal > Constellation Build Settings and configure it.";
+    private const string ERR_MSG_TOO_MANY_SETTINGS = "There are more than one ConstellationBuildSettings objects in the project. Remove all except one and check the configuration.";
 }


### PR DESCRIPTION
This PR moves the `GetDefaults()` method of the ConstellationBuildPreprocessor into a more sensible location (the settings class) and is necessary for [MKE-1197](https://teleportal.atlassian.net/browse/MKE-1197).