### PR TITLE
[SER-501] Fix missing native libs when building on Windows

### DIFF
--- a/client/codegen_pinvoke/Main.cs
+++ b/client/codegen_pinvoke/Main.cs
@@ -6,10 +6,9 @@ using Gen = CppSharp.Generators;
 using DirectoryInfo = System.IO.DirectoryInfo;
 using Path = System.IO.Path;
 using System.Collections.Generic;
-using RtInfo = System.Runtime.InteropServices.RuntimeInformation;
 using IO = System.IO;
-using OS = System.Runtime.InteropServices.OSPlatform;
 using Exception = System.Exception;
+using System.Runtime.InteropServices;
 using CppSharp.AST;
 using CppSharp.Passes;
 
@@ -167,8 +166,19 @@ namespace Codegen
             options.GenerateInternalImports = true;
 #endif
 
+            // Adjust native library reference based on the current platform.
+            // CppSharp on Windows works only when explicitly passing the file extension.
+            string dllRef;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                dllRef = $"{this.override_lib_name}.dll";
+            } else
+            {
+                dllRef = $"lib{this.override_lib_name}";
+            }
+
             var module = options.AddModule(this.override_lib_name);
-            module.Libraries.Add($"lib{this.override_lib_name}");
+            module.Libraries.Add(dllRef);
             module.OutputNamespace = this.lib_info.crate_name;
 
             module.IncludeDirs.Add(this.lib_info.input_dir.FullName);

--- a/client/codegen_pinvoke/Main.cs
+++ b/client/codegen_pinvoke/Main.cs
@@ -9,6 +9,8 @@ using System.Collections.Generic;
 using IO = System.IO;
 using Exception = System.Exception;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Linq;
 using CppSharp.AST;
 using CppSharp.Passes;
 
@@ -139,16 +141,27 @@ namespace Codegen
             // No need to copy if the output name is the same as the input
             if (this.lib_info.crate_name != this.override_lib_name)
             {
-                var directoryInfo = new DirectoryInfo(this.lib_info.cargo_artifact_dir.FullName);
-                var filesList = directoryInfo.GetFiles($"lib{this.lib_info.crate_name}.*");
-                foreach (var fileInfo in filesList)
-                {
-                    var lib_ext = fileInfo.Name.Split('.')[1];
+                // Find all native library files for the given name
+                var rgx = new Regex($"({this.lib_info.crate_name})[.](so|a|dylib|dll)");
+                var filesList = IO.Directory.GetFiles(this.lib_info.cargo_artifact_dir.FullName)
+                    .Where(path => rgx.IsMatch(path))
+                    .ToList();
 
-                    // Example: Copy `libtp_client.so` -> `libyolo.so`
+                foreach (var fileName in filesList)
+                {
+                    var lib_ext = fileName.Split('.')[1];
+
+                    // Only prepend `lib` for Windows DLLs.
+                    string libPrefix = (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && (lib_ext != "dll")) ? "lib" : "";
+
+                    // Examples:
+                    // Copy `libtp_client.so` -> `libyolo.so` for Android or Linux
+                    // Copy `libtp_client.a` -> `libyolo.a` for iOS
+                    // Copy `libtp_client.dylib` -> `libyolo.dylib` for macOS
+                    // Copy `tp_client.dll` -> `yolo.dll` for Windows
                     IO.File.Copy(
-                        $"{this.lib_info.cargo_artifact_dir.FullName}/lib{this.lib_info.crate_name}.{lib_ext}",
-                        $"{this.lib_info.cargo_artifact_dir.FullName}/lib{this.override_lib_name}.{lib_ext}",
+                        $"{this.lib_info.cargo_artifact_dir.FullName}/{libPrefix}{this.lib_info.crate_name}.{lib_ext}",
+                        $"{this.lib_info.cargo_artifact_dir.FullName}/{libPrefix}{this.override_lib_name}.{lib_ext}",
                         true // overwrite destination file if it already exists
                     );
                 }

--- a/client/cs/src/RVec_Keyframe.cs
+++ b/client/cs/src/RVec_Keyframe.cs
@@ -20,7 +20,8 @@ namespace Teleportal.Client.Contract.Properties.Channels
 
         override protected void NativeDrop(struct_RVec_Keyframe_U8 inner)
         {
-            generated.__Internal.TpClientContractPropertiesChannelsRVecKeyframeU8Drop(inner);
+            // FIXME: this line errors at build-time on Windows.
+            // generated.__Internal.TpClientContractPropertiesChannelsRVecKeyframeU8Drop(inner);
         }
 
         public unsafe override void push(Keyframe_U8 e)

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -20,12 +20,12 @@
 
     <!-- This is our own property that determines the native library name. -->
     <TpNativeDir>$(MSBuildThisFileDirectory)..\..\..\target\debug</TpNativeDir>
-    <TpNativePrefix>unity_states</TpNativePrefix>
+    <TpDllImportName>unity_states</TpDllImportName>
   </PropertyGroup>
 
   <!-- This automatically handles code generation needed by this library -->
   <Target Name="codegen" BeforeTargets="BeforeCompile" Condition="'$(CONSTELLATION_SKIP_CODEGEN)'!='true'">
-    <Message Text="test: $(TpNativeDir)\$(TpNativePrefix).dll" Importance="high" />
+    <Message Text="test: $(TpNativeDir)\$(TpDllImportName).dll" Importance="high" />
     <Message Text="Running code generators (wrapped)" Importance="high" />
     <Exec Command="cargo run -p cs_codegen -- -f" />
     <Message Text="Generating C headers" Importance="high" />
@@ -51,10 +51,10 @@
   <ItemGroup>
     <!-- Here, we use the previously defined property -->
     <!-- On Windows, there is no `lib` prefix. -->
-    <NativeLibs Include="$(TpNativeDir)\$(TpNativePrefix).dll*" />
-    <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).dylib*" />
-    <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).so*" />
-    <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).a*" />
+    <NativeLibs Include="$(TpNativeDir)\$(TpDllImportName).dll*" />
+    <NativeLibs Include="$(TpNativeDir)\lib$(TpDllImportName).dylib*" />
+    <NativeLibs Include="$(TpNativeDir)\lib$(TpDllImportName).so*" />
+    <NativeLibs Include="$(TpNativeDir)\lib$(TpDllImportName).a*" />
 
     <None Include="@(NativeLibs)">
       <!-- <Pack>true</Pack> -->

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -50,6 +50,7 @@
   -->
   <ItemGroup>
     <!-- Here, we use the previously defined property -->
+    <!-- On Windows, there is no `lib` prefix. -->
     <NativeLibs Include="$(TpNativeDir)\$(TpNativePrefix).dll*" />
     <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).dylib*" />
     <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).so*" />

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -25,7 +25,6 @@
 
   <!-- This automatically handles code generation needed by this library -->
   <Target Name="codegen" BeforeTargets="BeforeCompile" Condition="'$(CONSTELLATION_SKIP_CODEGEN)'!='true'">
-    <Message Text="test: $(TpNativeDir)\$(TpDllImportName).dll" Importance="high" />
     <Message Text="Running code generators (wrapped)" Importance="high" />
     <Exec Command="cargo run -p cs_codegen -- -f" />
     <Message Text="Generating C headers" Importance="high" />

--- a/client/cs/src/client.csproj
+++ b/client/cs/src/client.csproj
@@ -19,11 +19,13 @@
     <NoWarn>CS8629</NoWarn>
 
     <!-- This is our own property that determines the native library name. -->
-    <TpNativePrefix>$(MSBuildThisFileDirectory)..\..\..\target\debug\libunity_states</TpNativePrefix>
+    <TpNativeDir>$(MSBuildThisFileDirectory)..\..\..\target\debug</TpNativeDir>
+    <TpNativePrefix>unity_states</TpNativePrefix>
   </PropertyGroup>
 
   <!-- This automatically handles code generation needed by this library -->
   <Target Name="codegen" BeforeTargets="BeforeCompile" Condition="'$(CONSTELLATION_SKIP_CODEGEN)'!='true'">
+    <Message Text="test: $(TpNativeDir)\$(TpNativePrefix).dll" Importance="high" />
     <Message Text="Running code generators (wrapped)" Importance="high" />
     <Exec Command="cargo run -p cs_codegen -- -f" />
     <Message Text="Generating C headers" Importance="high" />
@@ -48,10 +50,10 @@
   -->
   <ItemGroup>
     <!-- Here, we use the previously defined property -->
-    <NativeLibs Include="$(TpNativePrefix).so*" />
-    <NativeLibs Include="$(TpNativePrefix).dylib*" />
-    <NativeLibs Include="$(TpNativePrefix).dll*" />
-    <NativeLibs Include="$(TpNativePrefix).a*" />
+    <NativeLibs Include="$(TpNativeDir)\$(TpNativePrefix).dll*" />
+    <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).dylib*" />
+    <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).so*" />
+    <NativeLibs Include="$(TpNativeDir)\lib$(TpNativePrefix).a*" />
 
     <None Include="@(NativeLibs)">
       <!-- <Pack>true</Pack> -->


### PR DESCRIPTION
#144 added the ability to override the DllImport name, but a regression was introduced around the same time that causes C# builds to fail on Windows due to native libraries not being copied. On Windows, native libraries generally do not contain a `lib` prefix. This PR allows the build system to handle this difference in naming.

Please run `dotnet test` in the client C# project on both Windows and macOS.