### PR TITLE
[SER-504] Fix ObjectHandle shared ref semantics

### DIFF
--- a/client/codegen_wrapped/src/type_info.rs
+++ b/client/codegen_wrapped/src/type_info.rs
@@ -156,7 +156,7 @@ type_info!(
     "Teleportal.Client.Object.ObjectHandle",
     false,
     "Teleportal.Client.Object.ObjectHandle",
-    O::Owned,
+    O::Ref,
 );
 type_info!(
     ContractDataHandle,
@@ -165,5 +165,5 @@ type_info!(
     "Teleportal.Client.Contract.ContractDataHandle",
     false,
     "Teleportal.Client.Contract.ContractDataHandle",
-    O::Owned,
+    O::Ref,
 );

--- a/client/codegen_wrapped/src/type_info.rs
+++ b/client/codegen_wrapped/src/type_info.rs
@@ -156,7 +156,7 @@ type_info!(
     "Teleportal.Client.Object.ObjectHandle",
     false,
     "Teleportal.Client.Object.ObjectHandle",
-    O::Ref,
+    O::Both,
 );
 type_info!(
     ContractDataHandle,
@@ -165,5 +165,5 @@ type_info!(
     "Teleportal.Client.Contract.ContractDataHandle",
     false,
     "Teleportal.Client.Contract.ContractDataHandle",
-    O::Ref,
+    O::Both,
 );

--- a/client/codegen_wrapped/state_id.cs.tpl
+++ b/client/codegen_wrapped/state_id.cs.tpl
@@ -4,6 +4,6 @@ public unsafe ContractDataHandle Contract
     {
         var raw_ptr = generated.__Internal.TpClientContractPropertiesStatesStateId{{inner_mangled_name}}Contract(this.Inner.Value.p);
         var ptr = new Ptr<ContractDataHandle>(raw_ptr);
-        return new ContractDataHandle(ptr, OwnershipSemantics.SharedRef);
+        return new ContractDataHandle(ptr, OwnershipSemantics.Owned);
     }
 }

--- a/client/codegen_wrapped/state_id.cs.tpl
+++ b/client/codegen_wrapped/state_id.cs.tpl
@@ -4,6 +4,6 @@ public unsafe ContractDataHandle Contract
     {
         var raw_ptr = generated.__Internal.TpClientContractPropertiesStatesStateId{{inner_mangled_name}}Contract(this.Inner.Value.p);
         var ptr = new Ptr<ContractDataHandle>(raw_ptr);
-        return new ContractDataHandle(ptr);
+        return new ContractDataHandle(ptr, OwnershipSemantics.SharedRef);
     }
 }

--- a/client/contract_example/cs/src/ExampleContract.cs
+++ b/client/contract_example/cs/src/ExampleContract.cs
@@ -44,7 +44,7 @@ namespace Teleportal.Example.Contract
                         this.Inner.Value.p
                     )
                 );
-                return new ContractDataHandle(p);
+                return new ContractDataHandle(p, OwnershipSemantics.SharedRef);
             }
         }
 
@@ -72,7 +72,7 @@ namespace Teleportal.Example.Contract
                 throw new OwnershipException("`str_0` must be owned");
             }
             var p = new Ptr<ObjectHandle>(generated.TpContractExampleExampleContractObjectCreate(this.Inner.Value.p, baseline.Inner.Value.p, u8_0, u8_1, i8_0, i8_1, f32_0, f32_1, str_0.StealInner().p));
-            return new ObjectHandle(p);
+            return new ObjectHandle(p, OwnershipSemantics.SharedRef);
         }
 
         public void ObjectRemove(Baseline baseline, ObjectHandle obj)

--- a/client/contract_example/cs/src/ExampleContract.cs
+++ b/client/contract_example/cs/src/ExampleContract.cs
@@ -44,7 +44,7 @@ namespace Teleportal.Example.Contract
                         this.Inner.Value.p
                     )
                 );
-                return new ContractDataHandle(p, OwnershipSemantics.SharedRef);
+                return new ContractDataHandle(p, OwnershipSemantics.Owned);
             }
         }
 
@@ -72,7 +72,7 @@ namespace Teleportal.Example.Contract
                 throw new OwnershipException("`str_0` must be owned");
             }
             var p = new Ptr<ObjectHandle>(generated.TpContractExampleExampleContractObjectCreate(this.Inner.Value.p, baseline.Inner.Value.p, u8_0, u8_1, i8_0, i8_1, f32_0, f32_1, str_0.StealInner().p));
-            return new ObjectHandle(p, OwnershipSemantics.SharedRef);
+            return new ObjectHandle(p, OwnershipSemantics.Owned);
         }
 
         public void ObjectRemove(Baseline baseline, ObjectHandle obj)

--- a/client/cs/src/Contract.cs
+++ b/client/cs/src/Contract.cs
@@ -8,7 +8,7 @@ namespace Teleportal.Client.Contract
 {
     public sealed class ContractDataHandle : OpaqueWrapper<ContractDataHandle>
     {
-        public ContractDataHandle(Ptr<ContractDataHandle> inner) : base(inner, OwnershipSemantics.Owned) { }
+        public ContractDataHandle(Ptr<ContractDataHandle> inner, OwnershipSemantics semantics) : base(inner, semantics) { }
 
         override protected void NativeDrop(Ptr<ContractDataHandle> inner)
         {

--- a/client/cs/src/ObjectHandle.cs
+++ b/client/cs/src/ObjectHandle.cs
@@ -8,7 +8,7 @@ namespace Teleportal.Client.Object
 {
     public sealed class ObjectHandle : OpaqueWrapper<ObjectHandle>
     {
-        public ObjectHandle(Ptr<ObjectHandle> inner) : base(inner, OwnershipSemantics.SharedRef) { }
+        public ObjectHandle(Ptr<ObjectHandle> inner, OwnershipSemantics semantics) : base(inner, semantics) { }
 
         override protected void NativeDrop(Ptr<ObjectHandle> inner)
         {

--- a/client/cs/src/ObjectHandle.cs
+++ b/client/cs/src/ObjectHandle.cs
@@ -8,7 +8,7 @@ namespace Teleportal.Client.Object
 {
     public sealed class ObjectHandle : OpaqueWrapper<ObjectHandle>
     {
-        public ObjectHandle(Ptr<ObjectHandle> inner) : base(inner, OwnershipSemantics.Owned) { }
+        public ObjectHandle(Ptr<ObjectHandle> inner) : base(inner, OwnershipSemantics.SharedRef) { }
 
         override protected void NativeDrop(Ptr<ObjectHandle> inner)
         {

--- a/client/cs/src/StateAccessors.cs
+++ b/client/cs/src/StateAccessors.cs
@@ -129,7 +129,7 @@ namespace Teleportal.Client
             var p = new Ptr<States.State_ObjectHandle>(
                 ffi.TpClientBaselineBaselineStateObjectHandle(this.Inner.Value.p, state_handle.Inner.Value.p)
             );
-            return new States.State_ObjectHandle(p, OwnershipSemantics.Owned);
+            return new States.State_ObjectHandle(p, OwnershipSemantics.SharedRef);
         }
 
         public States.State_String StateMut(States.StateHandle_String state_handle)

--- a/client/cs/src/StateAccessors.cs
+++ b/client/cs/src/StateAccessors.cs
@@ -129,7 +129,7 @@ namespace Teleportal.Client
             var p = new Ptr<States.State_ObjectHandle>(
                 ffi.TpClientBaselineBaselineStateObjectHandle(this.Inner.Value.p, state_handle.Inner.Value.p)
             );
-            return new States.State_ObjectHandle(p, OwnershipSemantics.SharedRef);
+            return new States.State_ObjectHandle(p, OwnershipSemantics.Owned);
         }
 
         public States.State_String StateMut(States.StateHandle_String state_handle)

--- a/demos/unity_states/cs/src/BallContract.cs
+++ b/demos/unity_states/cs/src/BallContract.cs
@@ -37,7 +37,7 @@ public class BallContract : OpaqueWrapper<BallContract>
         get
         {
             var p = new Ptr<ContractDataHandle>(ffi.BallContract_handle(this.Inner.Value.p));
-            return new ContractDataHandle(p);
+            return new ContractDataHandle(p, OwnershipSemantics.SharedRef);
         }
     }
 
@@ -76,7 +76,7 @@ public class BallContract : OpaqueWrapper<BallContract>
             scale_x, scale_y, scale_z,
             color
         ));
-        return new ObjectHandle(p);
+        return new ObjectHandle(p, OwnershipSemantics.SharedRef);
     }
 
     public static void ObjectRemove(Baseline baseline, ContractDataHandle contract)

--- a/demos/unity_states/cs/src/BallContract.cs
+++ b/demos/unity_states/cs/src/BallContract.cs
@@ -37,7 +37,7 @@ public class BallContract : OpaqueWrapper<BallContract>
         get
         {
             var p = new Ptr<ContractDataHandle>(ffi.BallContract_handle(this.Inner.Value.p));
-            return new ContractDataHandle(p, OwnershipSemantics.SharedRef);
+            return new ContractDataHandle(p, OwnershipSemantics.Owned);
         }
     }
 
@@ -76,7 +76,7 @@ public class BallContract : OpaqueWrapper<BallContract>
             scale_x, scale_y, scale_z,
             color
         ));
-        return new ObjectHandle(p, OwnershipSemantics.SharedRef);
+        return new ObjectHandle(p, OwnershipSemantics.Owned);
     }
 
     public static void ObjectRemove(Baseline baseline, ContractDataHandle contract)


### PR DESCRIPTION
`.Owned` causes a crash.